### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   },
   "bin": {
     "hash-mod": "bin/hash-mod"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
The [npmjs listing for hash-mod](https://www.npmjs.com/package/hash-mod) shows no licence. This update to the package.json corrects the listing to reflect the MIT licence found in the readme.md